### PR TITLE
Update 02-freq_sev.Rmd

### DIFF
--- a/_Documentation/bayesact/02-freq_sev.Rmd
+++ b/_Documentation/bayesact/02-freq_sev.Rmd
@@ -399,7 +399,7 @@ mv_model_fit =
     freq_data = freq_data_net,
     sev_data = sev_data,
 
-    priors = c(prior(normal(0, 1),
+    prior = c(prior(normal(0, 1),
                      class = Intercept,
                      resp = claimcount),
 


### PR DESCRIPTION
example has typo of  the argument `prior` as `priors` in the `brms_freq_sev` function, this causes an error when trying to run the example. removed `s` from code to run.